### PR TITLE
[Editorial] Refresh xref usage, drop custom script

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,23 +4,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>MPEG Audio Byte Stream Format</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-    <script src="https://w3c.github.io/media-source/media-source.js" class="remove"></script>
-    <script class="remove">
-      (function() {
-        var mpegContainerSpecDefinitions = {
-          'iso-11172-3': { fragment: 'https://www.iso.org/iso/catalogue_detail.htm?csnumber=22412', link_text: 'ISO/IEC 11172-3:1993', },
-          'iso-13818-3': { fragment: 'https://www.iso.org/iso/catalogue_detail.htm?csnumber=26797', link_text: 'ISO/IEC 13818-3:1998', },
-          'iso-14496-3': { fragment: 'https://www.iso.org/iso/catalogue_detail.htm?csnumber=53943', link_text: 'ISO/IEC 14496-3:2009', },
-          'id3v1': { fragment: 'https://id3.org/ID3v1', link_text: 'ID3v1', },
-          'id3v2': { fragment: 'https://id3.org/id3v2.3.0', link_text: 'ID3v2', },
-          'mpeg-mime-type': { fragment: '#mime-types', link_text: 'MIME-type', },
-          'mpeg-mime-types': { fragment: '#mime-types', link_text: 'MIME-types', },
-          'mpeg-audio-metadata-frames': { fragment: '#mpeg-metadata', link_text: 'Metadata Frames', },
-        };
-
-        mediaSourceAddDefinitionInfo("mpeg-byte-stream-format", "", mpegContainerSpecDefinitions);
-      })();
-    </script>
 
     <script class="remove">
       var respecConfig = {
@@ -41,45 +24,25 @@
         { name: "Aaron Colwell (until April 2015)",  url: "", company: "Google Inc.", companyURL: "https://www.google.com/" },
       ],
 
-      mseDefGroupName: "mpeg-byte-stream-format",
-      mseUnusedGroupNameExcludeList: ["media-source"],
-      mseContributors: [
-      ],
-
       // name of the WG
       group: "media",
 
-      scheme: "https",
+      github: "w3c/mse-byte-stream-format-mpeg-audio",
+      wgPublicList: "public-media-wg",
 
-      otherLinks: [{
-      key: 'Repository',
-      data: [{
-          value: 'We are on GitHub',
-          href: 'https://github.com/w3c/mse-byte-stream-format-mpeg-audio/'
-        }, {
-          value: 'File a bug',
-          href: 'https://github.com/w3c/mse-byte-stream-format-mpeg-audio/issues'
-        }, {
-          value: 'Commit history',
-          href: 'https://github.com/w3c/mse-byte-stream-format-mpeg-audio/commits/main/index.html'
-        }]
-      },{
-        key: 'Mailing list',
-        data: [{
-          value: 'public-media-wg@w3.org',
-          href: 'https://lists.w3.org/Archives/Public/public-media-wg/'
-        }]
-      }],
+      localBiblio: {
+        ID3v1: {
+          title: "ID3 tag version 1",
+          href: "https://id3.org/ID3v1",
+          publisher: "id3.org"
+        },
+        ID3v2: {
+          title: "ID3 tag version 2.3.0",
+          href: "https://id3.org/id3v2.3.0",
+          publisher: "id3.org"
+        }
+      }
 
-      preProcess: [ mediaSourceAddMainSpecDefinitionInfos, mediaSourcePreProcessor ],
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      postProcess: [ mediaSourcePostProcessor ],
-
-      xref: ["html"]
       };
     </script>
     <!-- script to register bugs -->
@@ -90,45 +53,45 @@
     <meta name="bug.component" content="Media Source Extensions">
     -->
   </head>
-  <body>
+  <body data-cite="html media-source">
     <section id="abstract">
-      This specification defines a <a def-id="mse-spec"></a> [[MEDIA-SOURCE]] byte stream format specification based on MPEG audio streams.
+      This specification defines a [[[MEDIA-SOURCE]]] [[MEDIA-SOURCE]] byte stream format specification based on MPEG audio streams.
     </section>
 
     <section id="sotd">
       <p>The working group maintains <a href="https://github.com/w3c/mse-byte-stream-format-mpeg-audio/issues">a list of all bug reports that the editors have not yet tried to address</a>;
-         there may also be related open bugs in the [[MEDIA-SOURCE]] repository.</p>
+      there may also be related open bugs in the <a href="https://github.com/w3c/media-source">GitHub repository</a>.</p>
       <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
     </section>
 
     <section id="introduction">
       <h2>Introduction</h2>
-      <p>This specification defines segment formats for implementations of <a def-id="mse-spec"></a> [[!MEDIA-SOURCE]] that choose to support MPEG audio streams specified in <a def-id="iso-11172-3"></a> [[!ISO11172-3]], <a def-id="iso-13818-3"></a> [[!ISO13818-3]], and <a def-id="iso-14496-3"></a> [[!ISO14496-3]].</p>
-      <p>It defines the <a def-id="mpeg-mime-types"></a> used to signal codecs, and provides the necessary format specific definitions for <a def-id="init-segments"></a>, <a def-id="media-segments"></a>, and <a def-id="random-access-points"></a> required by the <a def-id="byte-stream-formats-section"></a> of the Media Source Extensions spec. It also defines extra behaviors and state that only apply to this byte stream format.</p>
+      <p>This specification defines segment formats for implementations of [[[MEDIA-SOURCE]]] [[MEDIA-SOURCE]] that choose to support MPEG audio streams specified in [[ISO11172-3]], [[ISO13818-3]], and [[ISO14496-3]].</p>
+      <p>It defines the MIME-types (see [[[#mime-types]]]) used to signal codecs, and provides the necessary format specific definitions for [=initialization segments=], [=media segments=], and [=random access points=] required by the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification. This document also defines extra behaviors and state that only apply to this byte stream format.</p>
     </section>
 
     <section id="mime-types">
       <h2>MIME-types</h2>
-      <p>This section specifies the MIME-types that may be passed to <a def-id="isTypeSupported"></a> or <a def-id="addSourceBuffer"></a> for byte streams that conform to this specification.</p>
+      <p>This section specifies the MIME-types that may be passed to {{MediaSource/isTypeSupported()}} or {{MediaSource/addSourceBuffer()}} for byte streams that conform to this specification.</p>
       <ul>
-        <li>"audio/aac" for sequences of ADTS frames, as specified in <a def-id="iso-14496-3"></a>.</li>
-        <li>"audio/mpeg" for MPEG-1/2/2.5 Layer I/II/III streams, as specified in [[!RFC3003]].</li>
+        <li>"audio/aac" for sequences of ADTS frames, as specified in [[ISO14496-3]].</li>
+        <li>"audio/mpeg" for MPEG-1/2/2.5 Layer I/II/III streams, as specified in [[RFC3003]].</li>
       </ul>
       <p>The "codecs" MIME-type parameter MUST NOT be used with these MIME-types.</p>
     </section>
 
     <section>
       <h2>MPEG Audio Frames</h2>
-      <p>The format of an <dfn>MPEG Audio Frame</dfn> depends on the <a def-id="mpeg-mime-type"></a> used.</p>
+      <p>The format of an <dfn>MPEG Audio Frame</dfn> depends on the MIME type used (see [[[#mime-types]]]).</p>
       <ul>
-        <li>If the "audio/aac" MIME-type is used, an MPEG Audio Frame is a sequence of bytes that conform to the adts_frame() syntax specified in Table 1.A.5 of <a def-id="iso-14496-3"></a>.</li>
-        <li>If the "audio/mpeg" MIME-type is used, an MPEG Audio Frame is a sequence of bytes that conform to the frame() syntax element specified in Section 2.4.1.2 of <a def-id="iso-11172-3"></a> or the corresponding definition in <a def-id="iso-13818-3"></a>.</li>
+        <li>If the "audio/aac" MIME-type is used, an MPEG Audio Frame is a sequence of bytes that conform to the adts_frame() syntax specified in Table 1.A.5 of [[ISO14496-3]].</li>
+        <li>If the "audio/mpeg" MIME-type is used, an MPEG Audio Frame is a sequence of bytes that conform to the frame() syntax element specified in Section 2.4.1.2 of [[ISO11172-3]] or the corresponding definition in [[ISO13818-3]].</li>
       </ul>
     </section>
 
     <section id="mpeg-metadata">
-      <h4>Metadata Frames</h4>
-      <p>Since <a def-id="id3v1"></a>, <a def-id="id3v2"></a> metadata frames, and <a>Icecast headers</a> are common in existing MPEG audio streams, implementations SHOULD gracefully handle such frames. Zero or more of these metadata frames are allowed to occur before, after, or between <a>MPEG Audio Frame</a>. Minimal implementations MUST accept, consume, and ignore these frames. More advanced implementations MAY choose to expose the metadata information via an inband {{TextTrack}} or some other mechanism.</p>
+      <h4><dfn>Metadata Frames</dfn></h4>
+      <p>Since [[ID3v1]], [[ID3v2]] metadata frames, and <a>Icecast headers</a> are common in existing MPEG audio streams, implementations SHOULD gracefully handle such frames. Zero or more of these metadata frames are allowed to occur before, after, or between <a>MPEG Audio Frame</a>. Minimal implementations MUST accept, consume, and ignore these frames. More advanced implementations MAY choose to expose the metadata information via an inband {{TextTrack}} or some other mechanism.</p>
 
       <section id="icecast">
         <h3>Icecast headers</h3>
@@ -143,19 +106,14 @@
 
     <section id="mpeg-segments">
       <h4>Segment Definitions</h4>
-      <p>The MPEG audio byte stream is a combination of one or more <a>MPEG Audio Frame</a> and zero or more <a def-id="mpeg-audio-metadata-frames"></a>.</p>
+      <p>The MPEG audio byte stream is a combination of one or more <a>MPEG Audio Frame</a> and zero or more [=metadata frames=].</p>
       <ul>
-        <li>Every <a>MPEG Audio Frame</a> is a <a def-id="random-access-point"></a>.</li>
-        <li>Every <a>MPEG Audio Frame</a> header is an <a def-id="init-segment"></a>.</li>
-        <li>The coded audio in each <a>MPEG Audio Frame</a> is a <a def-id="media-segment"></a>.</li>
+        <li>Every <a>MPEG Audio Frame</a> is a [=random access point=].</li>
+        <li>Every <a>MPEG Audio Frame</a> header is an [=initialization segment=].</li>
+        <li>The coded audio in each <a>MPEG Audio Frame</a> is a [=media segment=].</li>
       </ul>
     </section>
 
     <section id="conformance"></section>
-
-<!--     <section id="acknowledgements">
-      <h2>Acknowledgments</h2>
-      The editors would like to thank <a def-id="contributors"></a> for their contributions to this specification.
-    </section> -->
   </body>
 </html>


### PR DESCRIPTION
See discussion in https://github.com/w3c/media-source/pull/337#issuecomment-1837837578

The references to ID3v1 and ID3v2 remain in the local biblio for now because the id3.org server, which hosts the specifications, returns a 500 Internal Server Error (and has been returning that error in the past few months). Not quite sure what to do with that.

Also, Specref has ID3 v2.4.0, but the spec probably means it when it references v2.3.0 as that is the "main" one in practice.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-mpeg-audio/pull/4.html" title="Last updated on Dec 5, 2023, 6:05 PM UTC (f2c500e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-mpeg-audio/4/df746bb...f2c500e.html" title="Last updated on Dec 5, 2023, 6:05 PM UTC (f2c500e)">Diff</a>