### PR TITLE
Refresh list of editors and SOTD

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,9 +19,17 @@
       // editors, add as many as you like
       // only "name" is required
       editors:  [
-        { name: "Dale Curtis", url: "", company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Matthew Wolenetz", mailto: "wolenetz@google.com", url: "", company: "Google Inc.", companyURL: "https://www.google.com/", w3cid: "76912" },
-        { name: "Aaron Colwell (until April 2015)",  url: "", company: "Google Inc.", companyURL: "https://www.google.com/" },
+        { name: "Dale Curtis",
+          company: "Google Inc.", companyURL: "https://www.google.com/",
+          w3cid: "135068" },
+        { name: "Matthew Wolenetz", mailto: "matt.wolenetz@gmail.com",
+          company: "W3C Invited Expert",
+          w3cid: "148095" },
+      ],
+
+      formerEditors: [
+        { name: "Aaron Colwell", note: "Until April 2015",  url: "",
+          company: "Google Inc.", companyURL: "https://www.google.com/" },
       ],
 
       // name of the WG
@@ -60,8 +68,7 @@
 
     <section id="sotd">
       <p>The working group maintains <a href="https://github.com/w3c/mse-byte-stream-format-mpeg-audio/issues">a list of all bug reports that the editors have not yet tried to address</a>;
-      there may also be related open bugs in the <a href="https://github.com/w3c/media-source">GitHub repository</a>.</p>
-      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
+      there may also be related open bugs in the <a href="https://github.com/w3c/media-source">GitHub repository</a> of the [[[MEDIA-SOURCE]]] specification.</p>
     </section>
 
     <section id="introduction">


### PR DESCRIPTION
Updated needed for the Media WG to resume publication of the note:
- Moved editors who are no longer in the group to the list of former editors.
- Dropped the paragraph about unstability before Candidate Recommendation stage from the Status of This Document section, as it does not apply to a Note.
- Completed the link to the GitHub repository of MSE.

Same updates as in https://github.com/w3c/mse-byte-stream-format-isobmff/pull/13


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-mpeg-audio/pull/6.html" title="Last updated on Dec 19, 2023, 1:58 PM UTC (f9a179c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-mpeg-audio/6/e9e8e8d...f9a179c.html" title="Last updated on Dec 19, 2023, 1:58 PM UTC (f9a179c)">Diff</a>